### PR TITLE
[WIP]8.0 migration and tests

### DIFF
--- a/prestashoperpconnect/models/product.py
+++ b/prestashoperpconnect/models/product.py
@@ -265,6 +265,90 @@ class product_product(orm.Model):
         return True
 
 
+
+class prestashop_product_product(orm.Model):
+    _name = 'prestashop.product.product'
+    _inherit = 'prestashop.binding'
+    _inherits = {'product.product': 'openerp_id'}
+
+    _columns = {
+        'openerp_id': fields.many2one(
+            'product.product',
+            string='Product',
+            required=True,
+            ondelete='cascade'
+        ),
+        # TODO FIXME what name give to field present in
+        # prestashop_product_product and product_product
+        'always_available': fields.boolean(
+            'Active',
+            help='if check, this object is always available'),
+        'quantity': fields.float(
+            'Computed Quantity',
+            help="Last computed quantity to send on Prestashop."
+        ),
+        'description_html': fields.html(
+            'Description',
+            translate=True,
+            help="Description html from prestashop",
+        ),
+        'description_short_html': fields.html(
+            'Short Description',
+            translate=True,
+        ),
+        'date_add': fields.datetime(
+            'Created At (on Presta)',
+            readonly=True
+        ),
+        'date_upd': fields.datetime(
+            'Updated At (on Presta)',
+            readonly=True
+        ),
+        'default_shop_id': fields.many2one(
+            'prestashop.shop',
+            'Default shop',
+            required=True
+        ),
+        'link_rewrite': fields.char(
+            'Friendly URL',
+            translate=True,
+            required=False,
+        ),
+        'reference': fields.char('Original reference'),
+    }
+
+    def recompute_prestashop_qty(self, cr, uid, ids, context=None):
+        if not hasattr(ids, '__iter__'):
+            ids = [ids]
+
+        for product in self.browse(cr, uid, ids, context=context):
+            new_qty = self._prestashop_qty(cr, uid, product, context=context)
+            self.write(
+                cr, uid, product.id,
+                {'quantity': new_qty},
+                context=context
+            )
+        return True
+
+    def _prestashop_qty(self, cr, uid, product, context=None):
+        if context is None:
+            context = {}
+        backend = product.backend_id
+        stock = backend.warehouse_id.lot_stock_id
+        stock_field = 'qty_available'
+        location_ctx = context.copy()
+        location_ctx['location'] = stock.id
+        product_stk = self.read(
+            cr, uid, product.id, [stock_field], context=location_ctx
+        )
+        return product_stk[stock_field]
+
+    _sql_constraints = [
+        ('prestashop_uniq', 'unique(backend_id, prestashop_id)',
+         "A product with the same ID on Prestashop already exists")
+    ]
+    
+
 class product_pricelist(orm.Model):
     _inherit = 'product.pricelist'
 

--- a/prestashoperpconnect/models/sale.py
+++ b/prestashoperpconnect/models/sale.py
@@ -22,7 +22,9 @@
 import openerp.addons.decimal_precision as dp
 
 from openerp.osv import fields, orm
+import logging
 
+_logger = logging.getLogger(__name__)
 
 class sale_order_state(orm.Model):
     _name = 'sale.order.state'

--- a/prestashoperpconnect/models/sale.py
+++ b/prestashoperpconnect/models/sale.py
@@ -229,3 +229,19 @@ class prestashop_sale_order_line_discount(orm.Model):
             select=True
         ),
     }
+
+    
+    def create(self, cr, uid, vals, context=None):
+        prestashop_order_id = vals['prestashop_order_id']
+        info = self.pool['prestashop.sale.order'].read(
+            cr, uid,
+            [prestashop_order_id],
+            ['openerp_id'],
+            context=context
+        )
+        order_id = info[0]['openerp_id']
+        _logger.debug("CREATE FROM discount")
+        vals['order_id'] = order_id[0]
+        return super(prestashop_sale_order_line_discount, self).create(
+            cr, uid, vals, context=context
+        )

--- a/prestashoperpconnect/product_combination.py
+++ b/prestashoperpconnect/product_combination.py
@@ -12,6 +12,7 @@ the main product.
 
 from unidecode import unidecode
 import json
+import logging
 
 from openerp import SUPERUSER_ID
 from openerp.osv import fields, orm
@@ -23,7 +24,7 @@ from .unit.import_synchronizer import import_batch
 from .unit.mapper import PrestashopImportMapper
 from .unit.import_synchronizer import import_record
 from openerp.addons.connector.unit.backend_adapter import BackendAdapter
-from openerp.addons.connector.unit.mapper import mapping
+from openerp.addons.connector.unit.mapper import (mapping, convert)
 from openerp.osv.orm import browse_record_list
 
 from openerp.addons.product.product import check_ean
@@ -38,6 +39,7 @@ try:
 except ImportError, e:
     from xml.etree import ElementTree
 
+_logger = logging.getLogger(__name__)
 
 @prestashop
 class ProductCombinationAdapter(GenericAdapter):
@@ -79,8 +81,24 @@ class ProductCombinationRecordImport(PrestashopImportSynchronizer):
 class ProductCombinationMapper(PrestashopImportMapper):
     _model_name = 'prestashop.product.combination'
 
+    def intToBoolconvert(field, conv_type):
+        ''' Convert the source field to a defined ``conv_type``
+        (ex. str) before returning it'''
+        def modifier(self, record, to_attr):
+            value = record[field]
+
+            if not value:
+                return None
+            if value == '1' :                 
+                converted = True
+            else : 
+                converted = False
+            
+            return converted
+        return modifier
+
     direct = [
-        ('default_on', 'default_on'),
+        (intToBoolconvert('default_on', bool), 'default_on'),
     ]
 
     from_main = []

--- a/prestashoperpconnect/unit/backend_adapter.py
+++ b/prestashoperpconnect/unit/backend_adapter.py
@@ -130,7 +130,7 @@ class GenericAdapter(PrestaShopCRUDAdapter):
 
         :rtype: list
         """
-        _logger.info('method search, model %s, filters ', self._prestashop_model, unicode(filters))
+        _logger.info('method search, model %s, filters %s ', self._prestashop_model, unicode(filters))
         api = self.connect()
         return api.search(self._prestashop_model, filters)
 

--- a/prestashoperpconnect/views/product_view.xml
+++ b/prestashoperpconnect/views/product_view.xml
@@ -1,26 +1,26 @@
 <?xml version="1.0" encoding="utf-8"?>
 <openerp>
     <data>
-            <record id="product_normal_form_view_default_check" model="ir.ui.view">
-           <field name="model">product.product</field>
-           <field name="inherit_id" ref="product.product_normal_form_view" />
-           <field name="arch" type="xml">
-               <field name="default_code" position="after">
+        <record id="product_normal_form_view_default_check" model="ir.ui.view">
+            <field name="model">product.product</field>
+            <field name="inherit_id" ref="product.product_normal_form_view" />
+            <field name="arch" type="xml">
+                <field name="default_code" position="after">
                     <field name="default_on"/>
-               </field>
+                </field>
                
-           </field>
+            </field>
         </record>
 
         <!--This is a product inherited form that will be dynamically populated-->
         <record id="product_normal_form_view" model="ir.ui.view">
-           <field name="model">product.product</field>
-           <field name="inherit_id" ref="connector_base_product.product_normal_form_view" />
-           <field name="arch" type="xml">
-               <page name="connector" position="attributes">
+            <field name="model">product.product</field>
+            <field name="inherit_id" ref="connector_base_product.product_normal_form_view" />
+            <field name="arch" type="xml">
+                <page name="connector" position="attributes">
                     <attribute name="invisible">0</attribute>
-               </page>
-               <page name="connector" position="inside">
+                </page>
+                <page name="connector" position="inside">
                     <group string="Prestashop Bindings">
                         <field
                             name="prestashop_bind_ids"
@@ -30,7 +30,7 @@
                             name="prestashop_combinations_bind_ids"
                             nolabel="1"
                         />
-<!--                         <field
+                        <!--                         <field
                             name="prestashop_bind_ids"
                             nolabel="1"
                             attrs="{'invisible': [('prestashop_bind_ids', '=', [])]}"
@@ -41,32 +41,32 @@
                             attrs="{'invisible': [('prestashop_combinations_bind_ids', '=', [])]}"
                         />   -->                      
                     </group>
-               </page>
-           </field>
+                </page>
+            </field>
         </record>
         
         <!--This is a product inherited form that will be dynamically populated-->
         <record id="product_normal_form_view" model="ir.ui.view">
-           <field name="model">product.template</field>
-           <field name="inherit_id" ref="connector_base_product.product_template_common_form" />
-           <field name="arch" type="xml">
-               <page name="connector" position="attributes">
+            <field name="model">product.template</field>
+            <field name="inherit_id" ref="connector_base_product.product_template_common_form" />
+            <field name="arch" type="xml">
+                <page name="connector" position="attributes">
                     <attribute name="invisible">0</attribute>
-               </page>
-               <page name="connector" position="inside">
+                </page>
+                <page name="connector" position="inside">
                     <group string="Prestashop Bindings">
                         <field
                             name="prestashop_bind_ids"
                             nolabel="1"
                         />
                     </group>
-               </page>
-           </field>
+                </page>
+            </field>
         </record>
 
         <record id="product_connector_presta_form_view" model="ir.ui.view">
-           <field name="model">prestashop.product.template</field>
-           <field name="arch" type="xml">
+            <field name="model">prestashop.product.template</field>
+            <field name="arch" type="xml">
                 <form string="prestashop fields">
                     <group col="1">
                         <field name="backend_id"/>
@@ -85,7 +85,7 @@
                         <field name="show_price"/>
                     </group>
                 </form>
-           </field>
+            </field>
         </record>
 
         <record id="product_connector_presta_tree_view" model="ir.ui.view">
@@ -99,26 +99,26 @@
                     <field name="prestashop_id"/>
                     <field name="reference"/>
                     <button name="recompute_prestashop_qty"
-                        class="oe_highlight"
-                        type="object"
-                        string="Export quantity"/>
+                            class="oe_highlight"
+                            type="object"
+                            string="Export quantity"/>
                     <button name="resync"
-                        type="object"
-                        string="Resync" />
+                            type="object"
+                            string="Resync" />
                 </tree>
             </field>
         </record>
 
         <record id="combination_connector_presta_form_view" model="ir.ui.view">
-           <field name="model">prestashop.product.combination</field>
-           <field name="arch" type="xml">
+            <field name="model">prestashop.product.combination</field>
+            <field name="arch" type="xml">
                 <form string="prestashop fields">
                     <group col="2">
                         <field name="backend_id"/>
                         <field name="quantity"/>
                     </group>
                 </form>
-           </field>
+            </field>
         </record>
 
         <record id="combination_connector_presta_tree_view" model="ir.ui.view">
@@ -130,12 +130,12 @@
                     <field name="prestashop_id"/>
                     <field name="reference"/>
                     <button name="recompute_prestashop_qty"
-                        class="oe_highlight"
-                        type="object"
-                        string="Export quantity"/>
+                            class="oe_highlight"
+                            type="object"
+                            string="Export quantity"/>
                     <button name="resync"
-                        type="object"
-                        string="Resync" />
+                            type="object"
+                            string="Resync" />
                 </tree>
             </field>
         </record>


### PR DESCRIPTION
The PR of this purpose is to track and log issue while migration is done.
Here is the conf used :
- Working with https://github.com/OCA/connector-prestashop/pull/11#issuecomment-133880810
- other dependencies referenced in https://github.com/OCA/connector-prestashop/pull/11
- Working with the prestapyt lib : https://github.com/pedrobaeza/connector-prestashop/pull/6#issuecomment-140726901
- Working with prestashop 1.5.6.2
- Starts with the latest branch https://github.com/pedrobaeza/connector-prestashop/tree/8.0_connector-prestashop_mig

Tests made :
- Metadatas synchro : Ok
- Import of customers : Ok

Failures :
- Product import with variants, problem on https://github.com/pedrobaeza/connector-prestashop/blob/8.0_connector-prestashop_mig/prestashoperpconnect/models/product_combination.py#L32 seems to not being taken into account in the model received from the API
- Product stock import failed :
  _import_stock_available / openerp.addons.prestashoperpconnect.unit.import_synchronizer.import_record('_import_stock_available', 1, {'id_product_attribute': '0', 'id_product': '410'})

```
  File "/home/florent/DEV/Serveurs/odoo/odoo/openerp/sql_db.py", line 234, in execute
    res = self._obj.execute(query, params)
IntegrityError: ERREUR:  une instruction insert ou update sur la table « stock_change_product_qty » viole la contrainte de clé
étrangère « stock_change_product_qty_product_id_fkey »
DÉTAIL : La clé (product_id)=(870) n'est pas présente dans la table « product_product ».
```
- Sale.order import failed :

```
)
  File "/home/florent/DEV/Projets_Ezytail/gitMag-connector-prestashop-pedrobaeza/prestashoperpconnect/unit/backend_adapter.py", line 145, in read
    res = api.get(self._prestashop_model, id, options=attributes)
  File "/usr/lib/python2.7/site-packages/prestapyt-0.4.0-py2.7.egg/prestapyt/prestapyt.py", line 516, in get
    response = super(PrestaShopWebServiceDict, self).get(resource, resource_id=resource_id, options=options)
  File "/usr/lib/python2.7/site-packages/prestapyt-0.4.0-py2.7.egg/prestapyt/prestapyt.py", line 366, in get
    return self.get_with_url(full_url)
  File "/usr/lib/python2.7/site-packages/prestapyt-0.4.0-py2.7.egg/prestapyt/prestapyt.py", line 536, in get_with_url
    response = super(PrestaShopWebServiceDict, self).get_with_url(url)
  File "/usr/lib/python2.7/site-packages/prestapyt-0.4.0-py2.7.egg/prestapyt/prestapyt.py", line 375, in get_with_url
    r = self._execute(url, 'GET')
  File "/usr/lib/python2.7/site-packages/prestapyt-0.4.0-py2.7.egg/prestapyt/prestapyt.py", line 206, in _execute
    self._check_status_code(r.status_code, r.content)
  File "/usr/lib/python2.7/site-packages/prestapyt-0.4.0-py2.7.egg/prestapyt/prestapyt.py", line 144, in _check_status_code
    ps_error_code, ps_error_msg = self._parse_error(content)
  File "/usr/lib/python2.7/site-packages/prestapyt-0.4.0-py2.7.egg/prestapyt/prestapyt.py", line 116, in _parse_error
    error_answer = self._parse(xml_content)
  File "/usr/lib/python2.7/site-packages/prestapyt-0.4.0-py2.7.egg/prestapyt/prestapyt.py", line 619, in _parse
    parsed_content = super(PrestaShopWebServiceDict, self)._parse(content)
  File "/usr/lib/python2.7/site-packages/prestapyt-0.4.0-py2.7.egg/prestapyt/prestapyt.py", line 219, in _parse
    raise PrestaShopWebServiceError('HTTP response is empty')
PrestaShopWebServiceError: ''
```
